### PR TITLE
Improve person queries

### DIFF
--- a/webapp/models.py
+++ b/webapp/models.py
@@ -106,7 +106,7 @@ class Person(models.Model):
 
     def siblings(self):
         return Person.objects.filter(pk__in=Partnership.children.through.objects.filter(
-            partnership__in=Partnership.objects.filter(children=self)).values('person_id'))
+            partnership__in=Partnership.objects.filter(children=self)).values('person_id')).exclude(pk=self.pk)
 
     class IllegalAgeError(ValidationError):
         def __init__(self):

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -96,13 +96,13 @@ class Person(models.Model):
         elif offset == 0:
             return self
         elif offset == 1:
-            return self.parents()
+            return Partnership.objects.filter(children=self)
         else:
             return Partnership.objects.filter(
                 children__in=Person.objects.filter(partnerships__in=self.get_generation(offset - 1)))
 
     def parents(self):
-        return Partnership.objects.filter(children=self)
+        return self.get_generation(1)
 
     def siblings(self):
         return Person.objects.filter(pk__in=Partnership.children.through.objects.filter(

--- a/webapp/tests.py
+++ b/webapp/tests.py
@@ -62,37 +62,37 @@ class PersonTestCase(TestCase):
         return partnership
 
     def test_get_parents(self):
-        parents = self.philip.parents()
+        parents = list(self.philip.parents())
         self.assertListEqual(self.gen1, parents)
 
     def test_get_gen_two(self):
-        generation = self.philip.get_generation(2)
+        generation = list(self.philip.get_generation(2))
         self.assertListEqual(self.gen2, generation)
 
     def test_get_gen_one(self):
-        generation = self.philip.get_generation(1)
+        generation = list(self.philip.get_generation(1))
         self.assertListEqual(self.gen1, generation)
 
     def test_get_gen_zero(self):
-        generation = self.philip.get_generation(0)
+        generation = [self.philip.get_generation(0)]
         self.assertListEqual(self.gen0, generation)
 
     def test_get_gen_neg_one(self):
-        generation = self.philip.get_generation(-1)
+        generation = list(self.philip.get_generation(-1))
         self.assertListEqual(self.genN1, generation)
 
     def test_get_gen_neg_two(self):
-        generation = self.philip.get_generation(-2)
+        generation = list(self.philip.get_generation(-2))
         self.assertListEqual(self.genN2, generation)
 
     def test_get_siblings(self):
         expected = [self.akira]
-        actual = self.colin.siblings()
+        actual = list(self.colin.siblings())
         self.assertListEqual(expected, actual)
 
     def test_get_siblings_empty_list(self):
         expected = []
-        actual = self.philip.siblings()
+        actual = list(self.philip.siblings())
         self.assertListEqual(expected, actual)
 
     def test_age_dead_with_death_date(self):


### PR DESCRIPTION
Helper methods on person all now result in only one database call. Reverted methods to return querysets, rather than lists, so that the queries can be appended to. This allows for even more complicated single calls to the database.