### PR TITLE
Updated Tree Detail View

### DIFF
--- a/webapp/forms.py
+++ b/webapp/forms.py
@@ -106,8 +106,15 @@ class AddPartnershipChild(ModelForm):
         self.fields['person'].queryset = Person.objects.filter(tree=tree)
 
 
-# Formset for form that adds partner (Person) to Partnership
-PersonFormSet = inlineformset_factory(Partnership, Person.partnerships.through, form=AddPersonPartnership, extra=1, can_delete=True)
+# Formset for form that adds partner (Person) to Partnership.
+# Specifically for an Add Partnership form, at least two slots are made avaiable
+# to add at least two people to the partnership
+NewPartnerFormSet = inlineformset_factory(Partnership, Person.partnerships.through, form=AddPersonPartnership, extra=2, can_delete=True)
+
+# Formset for form that adds partner (Person) to Partnership.
+# Specifically for an Edit Partnership form, at least one slot is made avaiable
+# to add at least one additional person to the partnership
+AddPartnerFormSet = inlineformset_factory(Partnership, Person.partnerships.through, form=AddPersonPartnership, extra=1, can_delete=True)
 
 # Formset for form that adds child (Person) to Partnership
 PartnershipChildFormSet = inlineformset_factory(Partnership, Partnership.children.through, form=AddPartnershipChild, extra=1, can_delete=True)

--- a/webapp/templates/base_generic.html
+++ b/webapp/templates/base_generic.html
@@ -48,7 +48,6 @@
                         <p></p>
                         <li><a href="{% url 'index' %}">Home</a></li>
                         <li><a href="{% url 'tree' %}">My Trees</a></li>
-                        <li><a href="{% url 'partnership' %}">All Partnerships</a></li>
                     {% else %}
                         <li><a href="{% url 'login' %}">Login</a></li>
                         <li><a href="{% url 'signup' %}">Create Account</a></li>

--- a/webapp/templates/webapp/partnership_list.html
+++ b/webapp/templates/webapp/partnership_list.html
@@ -1,24 +1,22 @@
-{% extends "base_generic.html" %}
-
-{% block content %}
-    <h1>Partnership List</h1>
-    {% if partnership_list %}
-        <ul>
-            {% for partnership in partnership_list %}
-                <li>
-                    <b>Partners:</b>
-                    {% for people in partnership.person_set.all %}
-                        <a href="{{ people.get_absolute_url }}">{{ people.legal_name }}</a>
-                        {% if not forloop.last %},{% endif %}
-                    {% endfor %}
-                    <br>
-                    {% include "webapp/boolean_checkbox.html" with key="Married" value=partnership.married %}<br>
-                    {% include "webapp/boolean_checkbox.html" with key="Current" value=partnership.current %}<br>
-                </li>
+<h3 style = "display:inline">Partnerships</h3>
+&nbsp;
+<a href="{% url 'add_partnership' tree.id %}" style="color:grey;opacity: 0.9;">add</a>
+{% if partnership_list %}
+    <ul>
+        {% for partnership in partnership_list %}
+            <li>
+                <b>Partners:</b>
+                {% for people in partnership.person_set.all %}
+                    <a href="{{ people.get_absolute_url }}">{{ people.legal_name }}</a>
+                    {% if not forloop.last %},{% endif %}
+                {% endfor %}
                 <br>
-            {% endfor %}
-        </ul>
-    {% else %}
-        <p>There are no partnerships in the library.</p>
-    {% endif %}
-{% endblock %}
+                {% include "webapp/boolean_checkbox.html" with key="Married" value=partnership.married %}<br>
+                {% include "webapp/boolean_checkbox.html" with key="Current" value=partnership.current %}<br>
+            </li>
+            <br>
+        {% endfor %}
+    </ul>
+{% else %}
+    <p>There are no partnerships in the tree.</p>
+{% endif %}

--- a/webapp/templates/webapp/person_list.html
+++ b/webapp/templates/webapp/person_list.html
@@ -1,4 +1,6 @@
-<h3>People List</h3>
+<h3 style = "display:inline">People</h3>
+&nbsp;
+<a href="{% url 'add_person' tree.id %}" style="color:grey;opacity: 0.9;">add</a>
 {% if person_list %}
      <ul>
         {% for person in person_list %}
@@ -14,5 +16,5 @@
         {% endfor %}
     </ul>
 {% else %}
-    <p>There are no people in the library.</p>
+    <p>There are no people in the tree.</p>
 {% endif %}

--- a/webapp/templates/webapp/tree_detail.html
+++ b/webapp/templates/webapp/tree_detail.html
@@ -13,7 +13,5 @@
 
     <!--Display the people list in the tree-->
     {% include "webapp/person_list.html" %}
-    <a href="{% url 'add_person' tree.id %}">Add Person</a>
-    <br>
-    <a href="{% url 'add_partnership' tree.id %}">Add Partnership</a>
+    {% include "webapp/partnership_list.html" %}
 {% endblock %}

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -31,7 +31,6 @@ urlpatterns = [
     path('tree/<int:tree_pk>/add_person/', views.add_person, name='add_person'),
     path('tree/<int:tree_pk>/person/<int:person_pk>/edit/', views.edit_person, name='edit_person'),
     path('person/delete/<int:person_pk>/<int:name_pk>/<int:tree_pk>/', views.delete_person, name="delete_person"),
-    path('partnership/', views.PartnershipListView.as_view(), name='partnership'),
     path('tree/<int:tree_pk>/add_partnership/', views.add_partnership, name='add_partnership'),
     path('tree/<int:tree_pk>/person/<int:person_pk>/partnership/<int:partnership_pk>/edit/', views.edit_partnership, name='edit_partnership'),
     path('person/delete/<int:partnership_pk>/<int:person_pk>/', views.delete_partnership, name="delete_partnership"),

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -130,7 +130,7 @@ def add_person(request, tree_pk):
                 created_person.save()
 
                 # redirect to page containing new Person instance's details
-                return redirect('person_detail', pk=created_person.id)
+                return redirect('tree_detail', pk=created_person.tree.id)
 
         # if a GET (or any other method) we'll create a blank form
         else:


### PR DESCRIPTION
- Added Partnership list to Tree detail view.
- Removed sidebar link to the separate Partnership list page.
- Added "Add" buttons next to People and Partnership lists in Tree detail view to add respective instances.
- Removed Add Person and Add Partnership buttons from bottom of Tree detail view.
- Adding a Person or Partnership will now redirect back to Tree detail view, in case more will be added.
- Add Partnership Form has two empty partner (Person) slots by default (changed from one empty slot), assuming at least two partners will initialize a Partnership.
- Edit Partnership Form still has one empty partner (Person) slot under the current partners, assuming at least one partner will be added to the Partnership.