### PR TITLE
Home redirect

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -2,9 +2,11 @@ from django.urls import path, include
 
 from accounts import views
 urlpatterns = [
+    path('login/', views.AccountLoginView.as_view(), name='login'),
+    path('logout/', views.AccountLogoutView.as_view(), name='logout'),
     path('', include('django.contrib.auth.urls')),
-    path('signup/', views.signup_view, name="signup"),
-    path('sent/', views.activation_sent_view, name="activation_sent"),
+    path('signup/', views.signup_view, name='signup'),
+    path('sent/', views.activation_sent_view, name='activation_sent'),
     path('activate/<slug:uidb64>/<slug:token>/', views.activate, name='activate'),
-    path('password_change', views.GoHomeAfterPasswordChange.as_view(), name='password_change')
+    path('password_change', views.GoHomeAfterPasswordChange.as_view(), name='password_change'),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,6 +1,7 @@
+from django.contrib import messages
 from django.contrib.auth import login
 from django.contrib.auth.models import User
-from django.contrib.auth.views import PasswordChangeView
+from django.contrib.auth.views import PasswordChangeView, LogoutView, LoginView
 from django.contrib.sites.shortcuts import get_current_site
 from django.shortcuts import redirect, render
 from django.template.loader import render_to_string
@@ -49,10 +50,31 @@ def activate(request, uidb64, token):
         user.is_active = True
         user.save()
         login(request, user)
-        return redirect('/webapp/?message=activation_success')
+        messages.add_message(request, messages.SUCCESS,
+                             'Your account was activated successfully. Welcome to Family Tree')
+        return redirect('/webapp/')
     else:
         return render(request, 'activation_invalid.html')
 
 
+class AccountLoginView(LoginView):
+    # Redirect url is in settings.py
+    def get_success_url(self):
+        messages.add_message(self.request, messages.SUCCESS, 'Logged in successfully. Welcome to Family Tree')
+        return super().get_success_url()
+
+
+class AccountLogoutView(LogoutView):
+    next_page = '/webapp/'
+
+    def get_next_page(self):
+        messages.add_message(self.request, messages.SUCCESS, 'Logged out.')
+        return super().get_next_page()
+
+
 class GoHomeAfterPasswordChange(PasswordChangeView):
-    success_url = '/webapp/?message=password_reset'
+    success_url = '/webapp/'
+
+    def get_success_url(self):
+        messages.add_message(self.request, messages.SUCCESS, 'Password reset successfully.')
+        return super().get_success_url()

--- a/familytree/settings.py
+++ b/familytree/settings.py
@@ -126,6 +126,6 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-LOGIN_REDIRECT_URL = '/webapp/?message=logged_in'
+LOGIN_REDIRECT_URL = '/webapp/'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/webapp/templates/base_generic.html
+++ b/webapp/templates/base_generic.html
@@ -46,7 +46,6 @@
                         <li><a href="{% url 'logout' %}?next=/">Logout</a></li>
                         <li><a href="{% url 'password_change' %}">Change password</a></li>
                         <p></p>
-                        <li><a href="{% url 'index' %}">Home</a></li>
                         <li><a href="{% url 'tree' %}">My Trees</a></li>
                     {% else %}
                         <li><a href="{% url 'login' %}">Login</a></li>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1,4 +1,3 @@
-from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.handlers.wsgi import WSGIRequest

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -329,6 +329,9 @@ def delete_tree(request, pk):
 
 
 def index(request):
+    if request.user.is_authenticated:
+        return redirect('tree')
+
     # Generate counts of Tree, Person, and Partnership
     num_tree = Tree.objects.all().count()
     num_person = Person.objects.all().count()

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -328,13 +328,6 @@ def delete_tree(request, pk):
     return redirect('tree')
 
 
-toast_messages = {
-    'logged_in': (messages.SUCCESS, 'Logged in successfully. Welcome to Family Tree'),
-    'password_reset': (messages.SUCCESS, 'Password reset successfully.'),
-    'activation_success': (messages.SUCCESS, 'Your account was activated successfully. Welcome to Family Tree')
-}
-
-
 def index(request):
     # Generate counts of Tree, Person, and Partnership
     num_tree = Tree.objects.all().count()
@@ -345,12 +338,6 @@ def index(request):
         'num_person': num_person,
         'num_partnerships': num_partnerships,
     }
-
-    message = request.GET.get('message')
-    if message and message in toast_messages:
-        messages.add_message(request, *toast_messages[message])
-        # Redirect to remove message parameter from url
-        return redirect('/webapp/')
 
     return render(request, 'index.html', context=context)
 


### PR DESCRIPTION
- Made messages independent from url
    - Previously, index handled all messages, and could be summoned by url
    - Now, all pages that extend base_generic can display queued messages
    - Note that the logic in base_generic is unchanged! What changed is where messages are added to the queue; previously, they were all added in the index view; now they are added in the logical place for the given message. For example, when a user logs in successfully, the login success message is added right there, and then shows on whatever page is next.
- Redirect logged in users to /tree/ from /index/
- Removed home page link from sidebar
