### PR TITLE
Added Sidebar Tree List & Tree List Page Traversal

### DIFF
--- a/webapp/templates/base_generic.html
+++ b/webapp/templates/base_generic.html
@@ -46,7 +46,8 @@
                         <li><a href="{% url 'logout' %}?next=/">Logout</a></li>
                         <li><a href="{% url 'password_change' %}">Change password</a></li>
                         <p></p>
-                        <li>{% include "webapp/sidebar_tree_list.html" %}<li>
+                        {% load tree_tag %}
+                        {% render_recent_trees user.id %}
                     {% else %}
                         <li><a href="{% url 'login' %}">Login</a></li>
                         <li><a href="{% url 'signup' %}">Create Account</a></li>

--- a/webapp/templates/base_generic.html
+++ b/webapp/templates/base_generic.html
@@ -46,7 +46,7 @@
                         <li><a href="{% url 'logout' %}?next=/">Logout</a></li>
                         <li><a href="{% url 'password_change' %}">Change password</a></li>
                         <p></p>
-                        <li><a href="{% url 'tree' %}">My Trees</a></li>
+                        <li>{% include "webapp/sidebar_tree_list.html" %}<li>
                     {% else %}
                         <li><a href="{% url 'login' %}">Login</a></li>
                         <li><a href="{% url 'signup' %}">Create Account</a></li>

--- a/webapp/templates/base_generic.html
+++ b/webapp/templates/base_generic.html
@@ -47,7 +47,7 @@
                         <li><a href="{% url 'password_change' %}">Change password</a></li>
                         <p></p>
                         {% load tree_tag %}
-                        {% render_recent_trees user.id %}
+                        {% render_recent_trees %}
                     {% else %}
                         <li><a href="{% url 'login' %}">Login</a></li>
                         <li><a href="{% url 'signup' %}">Create Account</a></li>

--- a/webapp/templates/base_generic.html
+++ b/webapp/templates/base_generic.html
@@ -47,7 +47,7 @@
                         <li><a href="{% url 'password_change' %}">Change password</a></li>
                         <p></p>
                         {% load tree_tag %}
-                        {% render_recent_trees %}
+                        {% render_sidebar_trees %}
                     {% else %}
                         <li><a href="{% url 'login' %}">Login</a></li>
                         <li><a href="{% url 'signup' %}">Create Account</a></li>

--- a/webapp/templates/webapp/sidebar_tree_list.html
+++ b/webapp/templates/webapp/sidebar_tree_list.html
@@ -1,7 +1,7 @@
 <h4>My Trees</h4>
 {% if sidebar_tree_list %}
     <ul>
-        {% for tree in sidebar_tree_list %}
+        {% for tree in sidebar_tree_list|slice:":5" %}
             <li>
                 <a href="{{ tree.get_absolute_url }}">{{ tree.title }}</a>   
             </li>

--- a/webapp/templates/webapp/sidebar_tree_list.html
+++ b/webapp/templates/webapp/sidebar_tree_list.html
@@ -1,12 +1,12 @@
 <h4>My Trees</h4>
-{% if sidebar_tree_list %}
+{% if trees %}
     <ul>
-        {% for tree in sidebar_tree_list|slice:":5" %}
+        {% for tree in trees %}
             <li>
                 <a href="{{ tree.get_absolute_url }}">{{ tree.title }}</a>   
             </li>
         {% endfor %}
-        {% if page_obj.has_next %}
+        {% if trees.has_next %}
             . . .</br>
             <a href="{% url 'tree' %}">View All</a>
         {% endif %}

--- a/webapp/templates/webapp/sidebar_tree_list.html
+++ b/webapp/templates/webapp/sidebar_tree_list.html
@@ -8,8 +8,9 @@
         {% endfor %}
         {% if trees.has_next %}
             . . .</br>
-            <a href="{% url 'tree' %}">View All</a>
+            <a href="{% url 'tree' %}">View All</a></br>
         {% endif %}
+        <a href="{% url 'add_tree' %}">Add Tree</a>
     </ul>
 {% else %}
     <ul>

--- a/webapp/templates/webapp/sidebar_tree_list.html
+++ b/webapp/templates/webapp/sidebar_tree_list.html
@@ -6,10 +6,7 @@
                 <a href="{{ tree.get_absolute_url }}">{{ tree.title }}</a>   
             </li>
         {% endfor %}
-        {% if page_obj.has_next %}
-            . . .</br>
-            <a href="{% url 'tree' %}">View All</a>
-        {% endif %}
+        <a href="{% url 'tree' %}">View All</a>
     </ul>
 {% else %}
     <ul>

--- a/webapp/templates/webapp/sidebar_tree_list.html
+++ b/webapp/templates/webapp/sidebar_tree_list.html
@@ -1,0 +1,18 @@
+<h4>My Trees</h4>
+{% if sidebar_tree_list %}
+    <ul>
+        {% for tree in sidebar_tree_list %}
+            <li>
+                <a href="{{ tree.get_absolute_url }}">{{ tree.title }}</a>   
+            </li>
+        {% endfor %}
+        {% if page_obj.has_next %}
+            . . .</br>
+            <a href="{% url 'tree' %}">View All</a>
+        {% endif %}
+    </ul>
+{% else %}
+    <ul>
+        <a href="{% url 'add_tree' %}">Create First Tree</a>
+    </ul>
+{% endif %}

--- a/webapp/templates/webapp/sidebar_tree_list.html
+++ b/webapp/templates/webapp/sidebar_tree_list.html
@@ -1,4 +1,4 @@
-<h4>My Trees</h4>
+<a href="{% url 'tree' %}" style="color:black;"><h5>My Trees</h5></a>
 {% if trees %}
     <ul>
         {% for tree in trees %}

--- a/webapp/templates/webapp/sidebar_tree_list.html
+++ b/webapp/templates/webapp/sidebar_tree_list.html
@@ -6,7 +6,10 @@
                 <a href="{{ tree.get_absolute_url }}">{{ tree.title }}</a>   
             </li>
         {% endfor %}
-        <a href="{% url 'tree' %}">View All</a>
+        {% if page_obj.has_next %}
+            . . .</br>
+            <a href="{% url 'tree' %}">View All</a>
+        {% endif %}
     </ul>
 {% else %}
     <ul>

--- a/webapp/templates/webapp/tree_list.html
+++ b/webapp/templates/webapp/tree_list.html
@@ -1,7 +1,9 @@
 {% extends "base_generic.html" %}
 
 {% block content %}
-    <h1>Tree List</h1>
+    <h1 style="display:inline">Tree List</h1>
+    &nbsp;
+    <a href="{% url 'add_tree' %}" style="color:grey;opacity: 0.9;">add</a>
     {% if tree_list %}
         <ul>
             {% for tree in tree_list %}
@@ -13,8 +15,26 @@
                 </li>
             {% endfor %}
         </ul>
+
+        <div class="pagination">
+            <span class="step-links">
+                {% if page_obj.has_previous %}
+                    <a href="?page=1">[first]</a>
+                    <a href="?page={{ page_obj.previous_page_number }}">[&lt&lt]</a>
+                {% endif %}
+
+                <span class="current">
+                    Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+                </span>
+
+                {% if page_obj.has_next %}
+                    <a href="?page={{ page_obj.next_page_number }}">[&gt&gt]</a>
+                    <a href="?page={{ page_obj.paginator.num_pages }}">[last]</a>
+                {% endif %}
+            </span>
+        </div>
+
     {% else %}
         <p>There are no trees in the library.</p>
     {% endif %}
-    <a href="{% url 'add_tree' %}">Add Tree</a>
 {% endblock %}

--- a/webapp/templatetags/tree_tag.py
+++ b/webapp/templatetags/tree_tag.py
@@ -1,0 +1,9 @@
+from django import template
+from webapp.models import Tree
+register = template.Library() 
+
+@register.inclusion_tag('webapp/sidebar_tree_list.html')
+def render_recent_trees(user):
+    return {
+        'sidebar_tree_list': Tree.objects.filter(creator=user).order_by("id")[:5]
+    }

--- a/webapp/templatetags/tree_tag.py
+++ b/webapp/templatetags/tree_tag.py
@@ -14,8 +14,8 @@ def render_sidebar_trees(context):
     page_number = request.GET.get('page')
     page_obj = paginator.get_page(page_number)
 
-    context = {
+    contexts = {
         'sidebar_tree_list': sidebar_tree_list,
         'page_obj': page_obj
     }
-    return context
+    return contexts

--- a/webapp/templatetags/tree_tag.py
+++ b/webapp/templatetags/tree_tag.py
@@ -1,9 +1,21 @@
 from django import template
 from webapp.models import Tree
-register = template.Library() 
+from django.core.paginator import Paginator
+register = template.Library()
 
-@register.inclusion_tag('webapp/sidebar_tree_list.html')
-def render_recent_trees(user):
-    return {
-        'sidebar_tree_list': Tree.objects.filter(creator=user).order_by("id")[:5]
+
+@register.inclusion_tag('webapp/sidebar_tree_list.html', takes_context=True)
+def render_recent_trees(context):
+    request = context['request']
+
+    sidebar_tree_list = Tree.objects.filter(creator=request.user).order_by("id")
+    paginator = Paginator(sidebar_tree_list, 5)
+
+    page_number = request.GET.get('page')
+    page_obj = paginator.get_page(page_number)
+
+    context = {
+        'sidebar_tree_list': sidebar_tree_list,
+        'page_obj': page_obj
     }
+    return context

--- a/webapp/templatetags/tree_tag.py
+++ b/webapp/templatetags/tree_tag.py
@@ -7,15 +7,9 @@ register = template.Library()
 @register.inclusion_tag('webapp/sidebar_tree_list.html', takes_context=True)
 def render_sidebar_trees(context):
     request = context['request']
-
     sidebar_tree_list = Tree.objects.filter(creator=request.user).order_by("id")
+
     paginator = Paginator(sidebar_tree_list, 5)
+    trees = paginator.page(1)
 
-    page_number = request.GET.get('page')
-    page_obj = paginator.get_page(page_number)
-
-    contexts = {
-        'sidebar_tree_list': sidebar_tree_list,
-        'page_obj': page_obj
-    }
-    return contexts
+    return {'trees': trees}

--- a/webapp/templatetags/tree_tag.py
+++ b/webapp/templatetags/tree_tag.py
@@ -5,7 +5,7 @@ register = template.Library()
 
 
 @register.inclusion_tag('webapp/sidebar_tree_list.html', takes_context=True)
-def render_recent_trees(context):
+def render_sidebar_trees(context):
     request = context['request']
 
     sidebar_tree_list = Tree.objects.filter(creator=request.user).order_by("id")

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -355,19 +355,6 @@ class TreeListView(LoginRequiredMixin, generic.ListView):
     def get_queryset(self):
         return Tree.objects.filter(creator=self.request.user)
 
-'''
-class SidebarTreeListView(LoginRequiredMixin, generic.ListView):
-    model = Tree
-    paginate_by = 5
-    ordering = ['id']
-    template_name = 'webapp/sidebar_tree_list.html'
-    context_object_name = 'sidebar_tree_list'
-
-    # Get Tree object only under the current user
-    def get_queryset(self):
-        return Tree.objects.filter(creator=self.request.user)
-'''
-
 
 # Have not integrate the partnership yet.
 class PartnershipListView(LoginRequiredMixin, generic.ListView):

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -355,17 +355,18 @@ class TreeListView(LoginRequiredMixin, generic.ListView):
     def get_queryset(self):
         return Tree.objects.filter(creator=self.request.user)
 
+'''
+class SidebarTreeListView(LoginRequiredMixin, generic.ListView):
+    model = Tree
+    paginate_by = 5
+    ordering = ['id']
+    template_name = 'webapp/sidebar_tree_list.html'
+    context_object_name = 'sidebar_tree_list'
 
-# class SidebarTreeListView(LoginRequiredMixin, generic.ListView):
-#     model = Tree
-#     paginate_by = 5
-#     ordering = ['id']
-#     template_name = 'webapp/sidebar_tree_list.html'
-#     context_object_name = 'sidebar_tree_list'
-
-#     # Get Tree object only under the current user
-#     def get_queryset(self):
-#         return Tree.objects.filter(creator=self.request.user)
+    # Get Tree object only under the current user
+    def get_queryset(self):
+        return Tree.objects.filter(creator=self.request.user)
+'''
 
 
 # Have not integrate the partnership yet.

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -354,16 +354,16 @@ class TreeListView(LoginRequiredMixin, generic.ListView):
     def get_queryset(self):
         return Tree.objects.filter(creator=self.request.user)
 
-class SidebarTreeListView(LoginRequiredMixin, generic.ListView):
-    model = Tree
-    paginate_by = 5
-    ordering = ['id']
-    template_name = 'webapp/sidebar_tree_list.html'
-    context_object_name = 'sidebar_tree_list'
+# class SidebarTreeListView(LoginRequiredMixin, generic.ListView):
+#     model = Tree
+#     paginate_by = 5
+#     ordering = ['id']
+#     template_name = 'webapp/sidebar_tree_list.html'
+#     context_object_name = 'sidebar_tree_list'
 
-    # Get Tree object only under the current user
-    def get_queryset(self):
-        return Tree.objects.filter(creator=self.request.user)
+#     # Get Tree object only under the current user
+#     def get_queryset(self):
+#         return Tree.objects.filter(creator=self.request.user)
 
 # Have not integrate the partnership yet.
 class PartnershipListView(LoginRequiredMixin, generic.ListView):

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -343,16 +343,18 @@ def index(request):
 
     return render(request, 'index.html', context=context)
 
+
 class TreeListView(LoginRequiredMixin, generic.ListView):
     model = Tree
     paginate_by = 10
     ordering = ['id']
     template_name = 'webapp/tree_list.html'
     context_object_name = 'tree_list'
-    
+
     # Get Tree object only under the current user
     def get_queryset(self):
         return Tree.objects.filter(creator=self.request.user)
+
 
 # class SidebarTreeListView(LoginRequiredMixin, generic.ListView):
 #     model = Tree
@@ -364,6 +366,7 @@ class TreeListView(LoginRequiredMixin, generic.ListView):
 #     # Get Tree object only under the current user
 #     def get_queryset(self):
 #         return Tree.objects.filter(creator=self.request.user)
+
 
 # Have not integrate the partnership yet.
 class PartnershipListView(LoginRequiredMixin, generic.ListView):

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -343,16 +343,27 @@ def index(request):
 
     return render(request, 'index.html', context=context)
 
-
 class TreeListView(LoginRequiredMixin, generic.ListView):
     model = Tree
     paginate_by = 10
     ordering = ['id']
+    template_name = 'webapp/tree_list.html'
+    context_object_name = 'tree_list'
+    
+    # Get Tree object only under the current user
+    def get_queryset(self):
+        return Tree.objects.filter(creator=self.request.user)
+
+class SidebarTreeListView(LoginRequiredMixin, generic.ListView):
+    model = Tree
+    paginate_by = 5
+    ordering = ['id']
+    template_name = 'webapp/sidebar_tree_list.html'
+    context_object_name = 'sidebar_tree_list'
 
     # Get Tree object only under the current user
     def get_queryset(self):
-        return super(TreeListView, self).get_queryset().filter(creator=self.request.user).select_related('creator')
-
+        return Tree.objects.filter(creator=self.request.user)
 
 # Have not integrate the partnership yet.
 class PartnershipListView(LoginRequiredMixin, generic.ListView):


### PR DESCRIPTION
- "My Trees" in the sidebar no longer has a link to the Tree List page.
- The sidebar now displays the first 5 trees the user has created.
- If there are more than 5 trees, users will see a "View All Trees" text whose link directs them to the Tree List page.
- Buttons have been added to traverse pages on the Tree List page.